### PR TITLE
feat(auth): implement proper Firebase sign-in and sign-up flows

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,12 @@
+import { isAuthenticated } from '@/lib/actions/auth.actions';
+import { redirect } from 'next/navigation';
 import React, { ReactNode } from 'react'
 
-const AuthLayout = ({ children }: { children: ReactNode}) => {
+const AuthLayout = async ({ children }: { children: ReactNode}) => {
+
+  const isUserAuthenticated = await isAuthenticated();
+
+    if(isUserAuthenticated) redirect('/');
   return (
     <div className='auth-layout'>
       {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import { isAuthenticated } from "@/lib/actions/auth.actions";
+import { redirect } from "next/navigation";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,11 +20,15 @@ export const metadata: Metadata = {
   description: "An AI interview platform which helps you prepare for interviews",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const isUserAuthenticated = await isAuthenticated();
+
+  if(!isUserAuthenticated) redirect('/sign-in');
+
   return (
     <html lang="en" className="dark">
       <body

--- a/lib/actions/auth.actions.ts
+++ b/lib/actions/auth.actions.ts
@@ -83,3 +83,36 @@ export async function setSessionCookie(idToken: string) {
     sameSite: 'lax',
   })
 }
+
+export async function getCurrentUser(): Promise<User | null> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session')?.value;
+
+  if(!sessionCookie) {
+    return null;
+  }
+
+  try {
+    const decodedClaims = await auth.verifySessionCookie(sessionCookie, true);
+    const userRecord = await db.
+    collection('users')
+    .doc(decodedClaims.uid)
+    .get();
+
+    if(!userRecord.exists) return null;
+
+    return {
+      ...userRecord.data(),
+      id: userRecord.id,
+    } as User;
+  } catch (error) {
+    console.error('Error verifying session cookie:', error);
+    return null;
+  }
+}
+
+export async function isAuthenticated() {
+  const user = await getCurrentUser();
+
+  return !!user;
+}


### PR DESCRIPTION
- Updated AuthForm to use createUserWithEmailAndPassword for sign-up and signInWithEmailAndPassword for sign-in.
- Ensured users receive appropriate feedback for account creation and login.
- Prevented "email already in use" errors during sign-in by using the correct Firebase method.